### PR TITLE
Remove duplicate test run from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ jobs:
       - run:
           command: npm run lint
       - run:
-          command: npm run test --ci
-      - run:
           command: npm run test:coverage --ci
       - run:
           command: npm run build


### PR DESCRIPTION
When running jest with coverage all tests are already executed. So why should they run twice?